### PR TITLE
[codex] Configure SAMURAI RT-DETR inference options

### DIFF
--- a/ml_module/cli_export_trt.py
+++ b/ml_module/cli_export_trt.py
@@ -6,10 +6,36 @@ from pathlib import Path
 from typing import Any, Dict
 
 
-def export_engine(weights_path: str) -> Dict[str, Any]:
+def export_engine(
+    weights_path: str,
+    *,
+    precision: str = "fp16",
+    data: str | None = None,
+    batch: int = 1,
+    fraction: float = 1.0,
+    dynamic: bool = False,
+) -> Dict[str, Any]:
     from ultralytics import RTDETR
+
+    precision = precision.lower()
+    if precision not in {"fp32", "fp16", "int8"}:
+        raise ValueError(f"Unsupported TensorRT precision: {precision}")
+    if precision == "int8" and not data:
+        raise ValueError("INT8 TensorRT export requires --data for calibration")
+
     m = RTDETR(weights_path)
-    m.export(format="engine", half=True)
+    kwargs: Dict[str, Any] = {
+        "format": "engine",
+        "half": precision == "fp16",
+        "int8": precision == "int8",
+        "batch": batch,
+        "dynamic": dynamic,
+    }
+    if data:
+        kwargs["data"] = data
+    if precision == "int8":
+        kwargs["fraction"] = fraction
+    m.export(**kwargs)
     wdir = Path(weights_path).parent
     candidates = list(wdir.rglob("best.engine")) + list(wdir.rglob("*.engine"))
     onnx_candidates = list(wdir.rglob("best.onnx")) + list(wdir.rglob("*.onnx"))
@@ -17,18 +43,35 @@ def export_engine(weights_path: str) -> Dict[str, Any]:
         "engine": str(candidates[0]) if candidates else None,
         "onnx": str(onnx_candidates[0]) if onnx_candidates else None,
         "pt": weights_path if weights_path.endswith(".pt") else None,
+        "precision": precision,
+        "data": data,
+        "batch": batch,
+        "fraction": fraction if precision == "int8" else None,
+        "dynamic": dynamic,
     }
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Export RT-DETR weights to TensorRT engine")
     ap.add_argument("--weights", required=True, help="Path to .pt or .onnx weights")
+    ap.add_argument("--precision", choices=["fp32", "fp16", "int8"], default="fp16")
+    ap.add_argument("--data", default=None, help="data.yaml path used for INT8 calibration")
+    ap.add_argument("--batch", type=int, default=1)
+    ap.add_argument("--fraction", type=float, default=1.0)
+    ap.add_argument("--dynamic", action="store_true")
     ap.add_argument("--result", required=True, help="Path to write JSON result")
     args = ap.parse_args()
 
     Path(args.result).parent.mkdir(parents=True, exist_ok=True)
 
-    res = export_engine(args.weights)
+    res = export_engine(
+        args.weights,
+        precision=args.precision,
+        data=args.data,
+        batch=args.batch,
+        fraction=args.fraction,
+        dynamic=args.dynamic,
+    )
     with open(args.result, "w", encoding="utf-8") as f:
         json.dump(res, f, ensure_ascii=False, indent=2)
     return 0
@@ -36,4 +79,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/ml_module/cli_infer_rtdetr.py
+++ b/ml_module/cli_infer_rtdetr.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 
 def run_inference(model_path: str, video_path: str, *, out_parquet: str, out_video: str | None = None,
-                  conf: float = 0.25, imgsz: int = 640) -> Dict[str, Any]:
+                  conf: float = 0.25, imgsz: int = 640, half: bool = False) -> Dict[str, Any]:
     from ultralytics import RTDETR
 
     cap = cv2.VideoCapture(video_path)
@@ -28,7 +28,7 @@ def run_inference(model_path: str, video_path: str, *, out_parquet: str, out_vid
 
     rows: List[Dict[str, Any]] = []
     frame_idx = -1
-    for results in model.predict(video_path, stream=True, verbose=True, conf=conf, imgsz=imgsz):
+    for results in model.predict(video_path, stream=True, verbose=True, conf=conf, imgsz=imgsz, half=half):
         frame_idx += 1
         names = results.names if hasattr(results, "names") else {}
         # boxes.xywh, boxes.cls
@@ -87,11 +87,12 @@ def main() -> int:
     ap.add_argument("--out-video", default=None, help="Optional output overlay mp4 path")
     ap.add_argument("--conf", type=float, default=0.25)
     ap.add_argument("--imgsz", type=int, default=640)
+    ap.add_argument("--half", action="store_true", help="Run PyTorch inference with FP16 where supported")
     ap.add_argument("--result", required=True, help="Path to write JSON result")
     args = ap.parse_args()
 
     res = run_inference(args.model, args.video, out_parquet=args.out_parquet, out_video=args.out_video,
-                        conf=args.conf, imgsz=args.imgsz)
+                        conf=args.conf, imgsz=args.imgsz, half=args.half)
     Path(args.result).parent.mkdir(parents=True, exist_ok=True)
     with open(args.result, "w", encoding="utf-8") as f:
         json.dump(res, f, ensure_ascii=False, indent=2)
@@ -100,4 +101,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/ml_module/cli_train_rtdetr.py
+++ b/ml_module/cli_train_rtdetr.py
@@ -18,6 +18,8 @@ def train_rtdetr(
     *,
     epochs: int = 1,
     base_model: str = "rtdetr-l.pt",
+    imgsz: int = 640,
+    pretrained: bool = True,
 ) -> Dict[str, Any]:
     dataset_dir = Path(dataset_dir)
     out_dir = Path(out_dir)
@@ -27,17 +29,16 @@ def train_rtdetr(
     if not data_yaml.is_file():
         raise FileNotFoundError(f"'data.yaml' is not found: {data_yaml}")
 
-    model_ref = base_model[:-3] + ".yaml" if base_model.endswith(".pt") else base_model
-    model = RTDETR(str(model_ref))
+    model = RTDETR(str(base_model))
 
     model.train(
         data=str(data_yaml),
         epochs=epochs,
-        imgsz=640,
+        imgsz=imgsz,
         name="train_result",
         project=str(out_dir),
         exist_ok=True,
-        pretrained=False,
+        pretrained=pretrained,
         batch=-1,  # auto-batch
     )
 
@@ -56,6 +57,8 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     ap.add_argument("--out-dir", required=True, help="学習成果物の出力ディレクトリ")
     ap.add_argument("--epochs", type=int, default=1)
     ap.add_argument("--base-model", default="rtdetr-l.pt")
+    ap.add_argument("--imgsz", type=int, default=640)
+    ap.add_argument("--pretrained", action=argparse.BooleanOptionalAction, default=True)
     ap.add_argument("--result", required=True, help="結果JSONの出力パス")
     return ap.parse_args(argv)
 
@@ -68,6 +71,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         out_dir=args.out_dir,
         epochs=args.epochs,
         base_model=args.base_model,
+        imgsz=args.imgsz,
+        pretrained=args.pretrained,
     )
 
     result_path = Path(args.result)

--- a/ml_module/model_samurai_ulr.py
+++ b/ml_module/model_samurai_ulr.py
@@ -553,13 +553,19 @@ class SamuraiULRModel:
         start_step("rtdetr_train")
         train_out = Path(work) / f"train_result_{Path(str(fid)).name}"
         train_json = Path(work) / f"train_result_{Path(str(fid)).name}.json"
+        rtdetr_epochs = int(os.getenv("RTDETR_EPOCHS", "12"))
+        rtdetr_base_model = os.getenv("RTDETR_BASE_MODEL", "rtdetr-l.pt")
+        rtdetr_imgsz = int(os.getenv("RTDETR_IMGSZ", "640"))
+        rtdetr_pretrained = os.getenv("RTDETR_PRETRAINED", "1").lower() not in {"0", "false", "no", "off"}
         rc = cmd_exec([
             "uv", "run", "-m", "ml_module.cli_train_rtdetr",
             # Pass absolute path under /workspace/src/datasets
             "--dataset", str(dataset_root),
             "--out-dir", str(train_out),
-            "--epochs", str(4),
-            "--base-model", "rtdetr-l.pt",
+            "--epochs", str(rtdetr_epochs),
+            "--base-model", rtdetr_base_model,
+            "--imgsz", str(rtdetr_imgsz),
+            "--pretrained" if rtdetr_pretrained else "--no-pretrained",
             "--result", str(train_json),
         ])
         print(f"[samurai] job={job_id} train rc={rc} out={train_json}")
@@ -580,9 +586,10 @@ class SamuraiULRModel:
             fail_step("rtdetr_train")
             raise RuntimeError("RT-DETR training did not produce weights.")
 
+        rtdetr_export_trt = os.getenv("RTDETR_EXPORT_TRT", "0").lower() not in {"0", "false", "no", "off"}
         try:
             model_engine = None
-            if model_pt:
+            if model_pt and rtdetr_export_trt:
                 # Check global cache to ensure we export TensorRT at most once per weights
                 with _TRT_EXPORT_LOCK:
                     cached = _TRT_EXPORT_CACHE.get(str(model_pt))
@@ -628,6 +635,10 @@ class SamuraiULRModel:
                     # Update cache with result (including None to avoid repeated attempts)
                     with _TRT_EXPORT_LOCK:
                         _TRT_EXPORT_CACHE[str(model_pt)] = model_engine
+            elif model_pt:
+                start_step("trt_export")
+                complete_step("trt_export")
+                print(f"[samurai] job={job_id} trt_export skipped; using PyTorch weights")
 
             # Pick an inference model path preference: engine > pt
             model_path = model_engine or model_pt
@@ -658,12 +669,14 @@ class SamuraiULRModel:
             out_parquet = str(work / "group_infer.parquet")
             out_video = str(work / "group_infer.mp4")
             out_json = str(work / "group_infer.json")
+            rtdetr_infer_conf = float(os.getenv("RTDETR_INFER_CONF", "0.25"))
             rc = cmd_exec([
                 "uv", "run", "-m", "ml_module.cli_infer_rtdetr",
                 "--model", str(global_model_path),
                 "--video", str(infer_input),
                 "--out-parquet", out_parquet,
                 "--out-video", out_video,
+                "--conf", str(rtdetr_infer_conf),
                 "--result", out_json,
             ])
             print(f"[samurai] job={job_id} rtdetr_infer rc={rc} input={infer_input}")

--- a/ml_module/model_samurai_ulr.py
+++ b/ml_module/model_samurai_ulr.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Dict, Tuple, Any
 import cv2
 import pandas as pd
 from threading import Lock
+from query.utils import first_result
 
 
 @dataclass
@@ -23,9 +24,55 @@ def _ensure_dir(p: str):
 
 
 # Cache for TensorRT exports to avoid repeated conversions per weights path
-# key: path to .pt weights, value: path to exported engine (or None if failed)
+# key: path + export options, value: path to exported engine (or None if failed)
 _TRT_EXPORT_CACHE: dict[str, Optional[str]] = {}
 _TRT_EXPORT_LOCK = Lock()
+
+
+INFERENCE_BACKEND_TENSORRT_FP16 = "tensorrt-fp16"
+INFERENCE_BACKEND_PYTORCH_FP32 = "pytorch-fp32"
+INFERENCE_BACKEND_PYTORCH_FP16 = "pytorch-fp16"
+INFERENCE_BACKENDS = {
+    INFERENCE_BACKEND_TENSORRT_FP16,
+    INFERENCE_BACKEND_PYTORCH_FP32,
+    INFERENCE_BACKEND_PYTORCH_FP16,
+}
+DEFAULT_RTDETR_EPOCHS = 4
+
+
+def _get_inference_backend(db_manager, job_id: str) -> str:
+    """Return the per-job inference backend, defaulting to legacy TensorRT FP16."""
+    try:
+        payload = db_manager.query(
+            "SELECT VALUE inferenceBackend FROM inference_job WHERE id = <record> $JOB_ID LIMIT 1",
+            {"JOB_ID": job_id},
+        )
+        value = first_result(payload)
+        backend = str(value or INFERENCE_BACKEND_TENSORRT_FP16)
+    except Exception:
+        backend = INFERENCE_BACKEND_TENSORRT_FP16
+
+    if backend not in INFERENCE_BACKENDS:
+        raise ValueError(f"Unsupported SAMURAI ULR inferenceBackend: {backend}")
+    return backend
+
+
+def _get_rtdetr_epochs(db_manager, job_id: str) -> int:
+    """Return the per-job RT-DETR training epoch count."""
+    default_epochs = int(os.getenv("RTDETR_EPOCHS", str(DEFAULT_RTDETR_EPOCHS)))
+    try:
+        payload = db_manager.query(
+            "SELECT VALUE rtdetrEpochs FROM inference_job WHERE id = <record> $JOB_ID LIMIT 1",
+            {"JOB_ID": job_id},
+        )
+        value = first_result(payload)
+        epochs = default_epochs if value in (None, "") else int(value)
+    except Exception:
+        epochs = default_epochs
+
+    if epochs < 1:
+        raise ValueError(f"rtdetrEpochs must be >= 1: {epochs}")
+    return epochs
 
 
 def _get_total_frame_count(video_path: str) -> int:
@@ -214,6 +261,8 @@ class SamuraiULRModel:
     def process_group(self, db_manager, job_id: str, file_group: List[Dict[str, Any]], work_dir: str) -> Dict[str, Any]:
         work = Path(work_dir)
         work.mkdir(parents=True, exist_ok=True)
+        inference_backend = _get_inference_backend(db_manager, str(job_id))
+        print(f"[samurai] job={job_id} inference_backend={inference_backend}")
 
         results_artifacts: List[Dict[str, str]] = []
         temp_datasets: List[str] = []
@@ -553,7 +602,7 @@ class SamuraiULRModel:
         start_step("rtdetr_train")
         train_out = Path(work) / f"train_result_{Path(str(fid)).name}"
         train_json = Path(work) / f"train_result_{Path(str(fid)).name}.json"
-        rtdetr_epochs = int(os.getenv("RTDETR_EPOCHS", "12"))
+        rtdetr_epochs = _get_rtdetr_epochs(db_manager, str(job_id))
         rtdetr_base_model = os.getenv("RTDETR_BASE_MODEL", "rtdetr-l.pt")
         rtdetr_imgsz = int(os.getenv("RTDETR_IMGSZ", "640"))
         rtdetr_pretrained = os.getenv("RTDETR_PRETRAINED", "1").lower() not in {"0", "false", "no", "off"}
@@ -586,8 +635,8 @@ class SamuraiULRModel:
             fail_step("rtdetr_train")
             raise RuntimeError("RT-DETR training did not produce weights.")
 
-        rtdetr_export_trt = os.getenv("RTDETR_EXPORT_TRT", "0").lower() not in {"0", "false", "no", "off"}
-        rtdetr_trt_precision = os.getenv("RTDETR_TRT_PRECISION", "fp16").lower()
+        rtdetr_export_trt = inference_backend == INFERENCE_BACKEND_TENSORRT_FP16
+        rtdetr_trt_precision = "fp16"
         rtdetr_trt_batch = int(os.getenv("RTDETR_TRT_BATCH", "1"))
         rtdetr_trt_fraction = float(os.getenv("RTDETR_TRT_FRACTION", "1.0"))
         rtdetr_trt_dynamic = os.getenv("RTDETR_TRT_DYNAMIC", "0").lower() not in {"0", "false", "no", "off"}
@@ -595,8 +644,9 @@ class SamuraiULRModel:
             model_engine = None
             if model_pt and rtdetr_export_trt:
                 # Check global cache to ensure we export TensorRT at most once per weights
+                cache_key = f"{model_pt}|precision={rtdetr_trt_precision}|batch={rtdetr_trt_batch}|fraction={rtdetr_trt_fraction}|dynamic={int(rtdetr_trt_dynamic)}"
                 with _TRT_EXPORT_LOCK:
-                    cached = _TRT_EXPORT_CACHE.get(str(model_pt))
+                    cached = _TRT_EXPORT_CACHE.get(cache_key)
                 if cached is not None:
                     model_engine = cached
                     # Even if cached, reflect that export is effectively complete
@@ -646,11 +696,11 @@ class SamuraiULRModel:
                             raise RuntimeError("TensorRT export failed.")
                     # Update cache with result (including None to avoid repeated attempts)
                     with _TRT_EXPORT_LOCK:
-                        _TRT_EXPORT_CACHE[str(model_pt)] = model_engine
+                        _TRT_EXPORT_CACHE[cache_key] = model_engine
             elif model_pt:
                 start_step("trt_export")
                 complete_step("trt_export")
-                print(f"[samurai] job={job_id} trt_export skipped; using PyTorch weights")
+                print(f"[samurai] job={job_id} trt_export skipped; using {inference_backend} weights")
 
             # Pick an inference model path preference: engine > pt
             model_path = model_engine or model_pt
@@ -682,7 +732,7 @@ class SamuraiULRModel:
             out_video = str(work / "group_infer.mp4")
             out_json = str(work / "group_infer.json")
             rtdetr_infer_conf = float(os.getenv("RTDETR_INFER_CONF", "0.25"))
-            rc = cmd_exec([
+            infer_cmd = [
                 "uv", "run", "-m", "ml_module.cli_infer_rtdetr",
                 "--model", str(global_model_path),
                 "--video", str(infer_input),
@@ -690,7 +740,10 @@ class SamuraiULRModel:
                 "--out-video", out_video,
                 "--conf", str(rtdetr_infer_conf),
                 "--result", out_json,
-            ])
+            ]
+            if inference_backend == INFERENCE_BACKEND_PYTORCH_FP16:
+                infer_cmd.append("--half")
+            rc = cmd_exec(infer_cmd)
             print(f"[samurai] job={job_id} rtdetr_infer rc={rc} input={infer_input}")
             if rc != 0 or not os.path.exists(out_parquet):
                 fail_step("rtdetr_infer")

--- a/ml_module/model_samurai_ulr.py
+++ b/ml_module/model_samurai_ulr.py
@@ -587,6 +587,10 @@ class SamuraiULRModel:
             raise RuntimeError("RT-DETR training did not produce weights.")
 
         rtdetr_export_trt = os.getenv("RTDETR_EXPORT_TRT", "0").lower() not in {"0", "false", "no", "off"}
+        rtdetr_trt_precision = os.getenv("RTDETR_TRT_PRECISION", "fp16").lower()
+        rtdetr_trt_batch = int(os.getenv("RTDETR_TRT_BATCH", "1"))
+        rtdetr_trt_fraction = float(os.getenv("RTDETR_TRT_FRACTION", "1.0"))
+        rtdetr_trt_dynamic = os.getenv("RTDETR_TRT_DYNAMIC", "0").lower() not in {"0", "false", "no", "off"}
         try:
             model_engine = None
             if model_pt and rtdetr_export_trt:
@@ -615,11 +619,19 @@ class SamuraiULRModel:
                     # Perform export only if not already resolved
                     if not model_engine:
                         start_step("trt_export")
-                        rc2 = cmd_exec([
+                        export_cmd = [
                             "uv", "run", "-m", "ml_module.cli_export_trt",
                             "--weights", str(model_pt),
+                            "--precision", rtdetr_trt_precision,
+                            "--batch", str(rtdetr_trt_batch),
+                            "--fraction", str(rtdetr_trt_fraction),
                             "--result", str(export_json),
-                        ])
+                        ]
+                        if rtdetr_trt_dynamic:
+                            export_cmd.append("--dynamic")
+                        if rtdetr_trt_precision == "int8":
+                            export_cmd.extend(["--data", str(dataset_root / "data.yaml")])
+                        rc2 = cmd_exec(export_cmd)
                         print(f"[samurai] job={job_id} trt_export rc={rc2} result={export_json}")
                         if rc2 == 0 and export_json.exists():
                             try:


### PR DESCRIPTION
## Summary
- Uses `RTDETR("rtdetr-l.pt")` directly for pretrained fine-tuning.
- Adds configurable RT-DETR TensorRT export options and per-job SAMURAI ULR inference backend selection.
- Supports `tensorrt-fp16`, `pytorch-fp32`, and `pytorch-fp16` execution modes.
- Adds per-job `rtdetrEpochs`, defaulting to 4 for compatibility with the prior UI default.

## Why
TensorRT engine inference on the current Blackwell/TensorRT path compresses RT-DETR confidences and can produce zero detections at the normal threshold, while PyTorch FP32/FP16 and ONNX outputs match expected results. Operators need to choose a reliable backend per SAMURAI ULR job while keeping TensorRT FP16 as the legacy default.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/mlops-pycache python3 -m py_compile ml_module/cli_train_rtdetr.py ml_module/model_samurai_ulr.py ml_module/cli_infer_rtdetr.py`
- `PYTHONPYCACHEPREFIX=/tmp/mlops-pycache python3 -m py_compile ml_module/cli_infer_rtdetr.py ml_module/model_samurai_ulr.py`
- Phase1 E2E passed in the companion `mlops-cloud` PR.
- Prior Phase4 E2E passed via the companion `mlops-cloud` PR.
